### PR TITLE
add new test for Dancer2::Status

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -5,7 +5,7 @@ use warnings;
 
 use  Test::WWW::Mechanize::PSGI;
 
-use Test::More tests => 6;
+use Test::More tests => 7;
 use Test::Deep;
 
     use Dancer2;
@@ -30,6 +30,11 @@ use Test::Deep;
     }, 
     get '/description/first_arg' => sub {};
 
+
+    get '/swagger_template' => sub {
+        return swagger_template;
+    };
+
 my $app = TestMe->to_app;
 $::mech = Test::WWW::Mechanize::PSGI->new( app => $app );
 
@@ -43,6 +48,7 @@ sub swagger_path_test {
     };
 }
 
+$::mech->get_ok( '/swagger_template' );
 
 swagger_path_test '/parameters/standard' => {
     parameters => [


### PR DESCRIPTION
Adding a new test that fails.

That's because the new Dancer2::status doesn't exist. To see how it has been replaced in Dancer2, look at the Dancer2::Core::DSL file, and check out the definition of the `status` sub. 

Remember that in Dancer2 the dsl keywords are not exported into the plugin, so you can't do

```
status(404);
```

but you'll have to use whatever is internal to that `sub status { ... }`. If it uses the application, within the plugin you can do

```
$plugin->app->whatever_app_function_you_want()
```

But in this case, you'll not even need to do that. 