### PR TITLE
swagger_response needs its object

### DIFF
--- a/lib/Dancer2/Plugin/OpenAPI.pm
+++ b/lib/Dancer2/Plugin/OpenAPI.pm
@@ -271,7 +271,7 @@ sub swagger_template :PluginKeyword {
 
     $Dancer2::Core::Route::RESPONSE->status( $status ) if $status =~ /^\d{3}$/;
 
-    return swagger_response( $status, $template ? $template->($vars) : $vars );
+    return $plugin->swagger_response( $status, $template ? $template->($vars) : $vars );
 };
 
 sub swagger_response :PluginKeyword {


### PR DESCRIPTION
That's why you were getting the error. :-)

Okay, tests are passing. Next steps are:

* I'd like to see a test added fo the use of `validate_response`.
* We should add in the documentation which version of Swagger/OpenApi the plugin conforms to.